### PR TITLE
Create copilot-instructions.md with coding guidelines

### DIFF
--- a/.github/workflows/copilot-instructions.md
+++ b/.github/workflows/copilot-instructions.md
@@ -1,0 +1,26 @@
+## General
+
+* Make only high confidence suggestions when reviewing code changes.
+* Always use the latest version C#, unless explicitly specified in csproj.
+
+## Formatting
+
+* Apply code-formatting style defined in `.editorconfig`.
+* Prefer file-scoped namespace declarations and single-line using directives.
+* Insert a newline before the opening curly brace of any code block (e.g., after `if`, `for`, `while`, `foreach`, `using`, `try`, etc.).
+* Ensure that the final return statement of a method is on its own line.
+* Use pattern matching and switch expressions wherever possible.
+* Use `nameof` instead of string literals when referring to member names.
+* Ensure that XML doc comments are created for any public APIs. When applicable, include `<example>` and `<code>` documentation in the comments. Use `<inheritdoc />` instead of rewriting comment of parent type's member.
+
+### Nullable Reference Types
+
+* Declare variables non-nullable, and check for `null` at entry points.
+* Always use `is null` or `is not null` instead of `== null` or `!= null`.
+* Trust the C# null annotations and don't add null checks when the type system says a value cannot be null.
+
+### Testing
+
+* Use NUnit SDK for tests.
+* Do not emit "Act", "Arrange" or "Assert" comments.
+* Copy existing style in nearby files for test method names and capitalization.


### PR DESCRIPTION
Added guidelines for code formatting, nullable reference types, and testing practices.
Inspiration taken from [dotnet/aspnetcore repo](https://github.com/dotnet/aspnetcore/blob/main/.github/copilot-instructions.md)