### PR TITLE
Reduce payload memory footprint; Add compression support;

### DIFF
--- a/src/Aer.QdrantClient.Http/Aer.QdrantClient.Http.csproj
+++ b/src/Aer.QdrantClient.Http/Aer.QdrantClient.Http.csproj
@@ -36,12 +36,16 @@
     <PackageReference Include="morelinq" Version="4.4.0" />
   </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="System.Text.Json" Version="9.0.10"/>
+    </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="9.0.8"/>
+    <PackageReference Include="System.Text.Json" Version="9.0.10"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Aer.QdrantClient.Http/Configuration/QdrantClientSettings.cs
+++ b/src/Aer.QdrantClient.Http/Configuration/QdrantClientSettings.cs
@@ -33,4 +33,14 @@ public sealed class QdrantClientSettings
     /// The default timeout for http client which ios used to call Qdrant HTTP API.
     /// </summary>
     public TimeSpan HttpClientTimeout { set; get; } = DefaultHttpClientTimeout;
+
+    /// <summary>
+    /// If set to <c>true</c>, http client activity tracing is disabled. Default is <c>false</c>.
+    /// </summary>
+    public bool DisableTracing { set; get; }
+    
+    /// <summary>
+    /// If set to <c>true</c> enables request \ response compression. Default is <c>false</c>.
+    /// </summary>
+    public bool EnableCompression { set; get; }
 }

--- a/src/Aer.QdrantClient.Http/HttpClientHanders/ApiKeyHttpClientHandler.cs
+++ b/src/Aer.QdrantClient.Http/HttpClientHanders/ApiKeyHttpClientHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace Aer.QdrantClient.Http.HttpClientHanders;
+
+internal class ApiKeyHttpClientHandler : DelegatingHandler
+{
+    private readonly string _apiKey;
+    
+    public ApiKeyHttpClientHandler(string apiKey, HttpMessageHandler innerHandler): base(innerHandler)
+    {
+        _apiKey = apiKey;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        request.Headers.Add(QdrantHttpClient.ApiKeyHeaderName, _apiKey);
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Aer.QdrantClient.Http/HttpClientHanders/DisableActivityHttpClientHandler.cs
+++ b/src/Aer.QdrantClient.Http/HttpClientHanders/DisableActivityHttpClientHandler.cs
@@ -1,13 +1,13 @@
 ﻿using System.Diagnostics;
 
-namespace Aer.QdrantClient.Http.Infrastructure.Tracing;
+namespace Aer.QdrantClient.Http.HttpClientHanders;
 
 /// <summary>
 /// The http client handler that disables activity propagation.
 /// </summary>
-internal sealed class DisableActivityHandler : DelegatingHandler
+internal sealed class DisableActivityHttpClientHandler : DelegatingHandler
 {
-	public DisableActivityHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+	public DisableActivityHttpClientHandler(HttpMessageHandler innerHandler) : base(innerHandler)
 	{ }
 
 	protected override async Task<HttpResponseMessage> SendAsync(

--- a/src/Aer.QdrantClient.Http/Infrastructure/Json/Converters/PayloadJsonConverter.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Json/Converters/PayloadJsonConverter.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Aer.QdrantClient.Http.Models.Primitives;
 
@@ -9,16 +8,17 @@ internal sealed class PayloadJsonConverter : JsonConverter<Payload>
 {
     public override Payload Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var payloadObject = JsonNode.Parse(ref reader)!.AsObject();
-
-        if (payloadObject.Count == 0)
+        using var jsonDoc = JsonDocument.ParseValue(ref reader);
+        
+        var readString = jsonDoc.RootElement.GetRawText();
+        if (readString.Equals(Payload.EmptyString, StringComparison.OrdinalIgnoreCase))
         {
             return Payload.Empty;
         }
 
         return new Payload()
         {
-            RawPayload = payloadObject
+            RawPayloadString = readString
         };
     }
 

--- a/src/Aer.QdrantClient.Http/Models/Responses/Snapshots/DownloadSnapshotResponse.cs
+++ b/src/Aer.QdrantClient.Http/Models/Responses/Snapshots/DownloadSnapshotResponse.cs
@@ -22,18 +22,19 @@ public sealed class DownloadSnapshotResponse : QdrantResponseBase<DownloadSnapsh
         /// The name of the snapshot. Used to name the temporary file on qdrant side.
         /// </summary>
         public string SnapshotName { get; }
+        
         /// <summary>
         /// The stream with binary snapshot data.
         /// </summary>
         public Stream SnapshotDataStream { get; }
 
         /// <summary>
-        /// The snapshot size in bytes.
+        /// The snapshot size in bytes. If using compression - has <c>0</c> value.
         /// </summary>
         public long SnapshotSizeBytes { get; }
 
         /// <summary>
-        /// The snapshot size in megabytes.
+        /// The snapshot size in megabytes. If using compression - has <c>0</c> value.
         /// </summary>
         public double SnapshotSizeMegabytes => SnapshotSizeBytes > 0
             ? SnapshotSizeBytes / 1024.0 / 1024.0

--- a/tests/Aer.QdrantClient.Tests/Base/QdrantTestsBase.cs
+++ b/tests/Aer.QdrantClient.Tests/Base/QdrantTestsBase.cs
@@ -1,4 +1,5 @@
 using Aer.QdrantClient.Http;
+using Aer.QdrantClient.Http.Configuration;
 using Aer.QdrantClient.Http.DependencyInjection;
 using Aer.QdrantClient.Http.Models.Primitives;
 using Aer.QdrantClient.Http.Models.Primitives.Vectors;
@@ -7,6 +8,7 @@ using Aer.QdrantClient.Http.Models.Shared;
 using Aer.QdrantClient.Tests.Model;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MoreLinq;
 using Polly.CircuitBreaker;
 using Serilog;
@@ -312,6 +314,14 @@ public class QdrantTestsBase
             Enumerable.Range(0, (int) vectorLength)
                 .Select(_ => vectorElement)
                 .ToArray();
+
+    protected QdrantClientSettings GetQdrantClientSettings(string clientName = null)
+    {
+        var qdrantSettings = ServiceProvider.GetRequiredService<IOptionsSnapshot<QdrantClientSettings>>()
+            .Get(clientName ?? ServiceCollectionExtensions.DefaultHttpClientName);
+
+        return qdrantSettings;
+    }
 
     /// <summary>
     /// Returns <see cref="QdrantHttpClient"/> for first node of the 2-node cluster.

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/CollectionsCompoundOperationsTests.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/CollectionsCompoundOperationsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Aer.QdrantClient.Http;
 using Aer.QdrantClient.Http.Configuration;
+using Aer.QdrantClient.Http.DependencyInjection;
 using Aer.QdrantClient.Http.Models.Primitives;
 using Aer.QdrantClient.Http.Models.Requests.Public;
 using Aer.QdrantClient.Http.Models.Requests.Public.Shared;
@@ -23,7 +24,10 @@ public class CollectionsCompoundOperationsTests : QdrantTestsBase
         Initialize();
 
         _qdrantHttpClient = ServiceProvider.GetRequiredService<QdrantHttpClient>();
-        _qdrantClientSettings = ServiceProvider.GetRequiredService<IOptions<QdrantClientSettings>>().Value;
+        
+        _qdrantClientSettings = ServiceProvider.GetRequiredService<IOptionsSnapshot<QdrantClientSettings>>().Get(
+            ServiceCollectionExtensions.DefaultHttpClientName);
+        
         _logger = ServiceProvider.GetRequiredService<ILogger<CollectionsCompoundOperationsTests>>();
     }
 

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/PointsScrollTests.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/PointsScrollTests.cs
@@ -278,6 +278,12 @@ internal class PointsScrollTests : QdrantTestsBase
         readPointsResult.Status.IsSuccess.Should().BeTrue();
         readPointsResult.Result.Points.Length.Should().Be(valuesToMatchAgainst.Count);
 
+        foreach (var readPoint in readPointsResult.Result.Points)
+        { 
+            readPoint.Payload.IsEmpty.Should().BeFalse();
+            readPoint.Payload.RawPayload.Should().NotBeNull();
+        }
+
         var readPointsRangeResult = await _qdrantHttpClient.ScrollPoints(
             TestCollectionName,
             Q.Must(
@@ -301,6 +307,8 @@ internal class PointsScrollTests : QdrantTestsBase
             var expectedPoint = upsertPointsByPointIds[readPointId];
 
             expectedPoint.Id.As<IntegerPointId>().Id.Should().Be(readPointId);
+
+            readPoint.Payload.RawPayload.Should().NotBeNull();
 
             readPoint.Payload.As<TestPayload>().Integer.Should().Be(expectedPoint.Payload.Integer);
             readPoint.Payload.As<TestPayload>().FloatingPointNumber.Should().Be(expectedPoint.Payload.FloatingPointNumber);

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/CollectionSnapshotTests.Multinode.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/CollectionSnapshotTests.Multinode.cs
@@ -1,4 +1,5 @@
 ﻿using Aer.QdrantClient.Http;
+using Aer.QdrantClient.Http.Configuration;
 using Aer.QdrantClient.Http.Models.Requests.Public;
 using Aer.QdrantClient.Http.Models.Responses;
 using Aer.QdrantClient.Http.Models.Shared;
@@ -13,12 +14,14 @@ public class CollectionSnapshotTestsMultiNode : SnapshotTestsBase
 {
     private QdrantHttpClient _qdrantHttpClientClusterNode1;
     private QdrantHttpClient _qdrantHttpClientClusterNode2;
+    private QdrantClientSettings _clientSettings;
 
     [OneTimeSetUp]
     public void Setup()
     {
         Initialize();
 
+        _clientSettings = GetQdrantClientSettings();
         _qdrantHttpClientClusterNode1 = GetClusterClient(ClusterNode.First);
         _qdrantHttpClientClusterNode2 = GetClusterClient(ClusterNode.Second);
     }
@@ -266,7 +269,12 @@ public class CollectionSnapshotTestsMultiNode : SnapshotTestsBase
         {
             downloadedSnapshot.Status.IsSuccess.Should().BeTrue();
             downloadedSnapshot.Result.SnapshotName.Should().Be(createdSnapshot.Name);
-            downloadedSnapshot.Result.SnapshotSizeBytes.Should().Be(createdSnapshot.Size);
+
+            downloadedSnapshot.Result.SnapshotSizeBytes.Should().Be(
+                !_clientSettings.EnableCompression
+                    ? createdSnapshot.Size
+                    : 0
+            );
 
             downloadedSnapshot.Result.SnapshotDataStream.Should().NotBeNull();
             downloadedSnapshot.Result.SnapshotType.Should().Be(SnapshotType.Collection);

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/CollectionSnapshotTests.SingleNode.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/CollectionSnapshotTests.SingleNode.cs
@@ -1,4 +1,5 @@
 ﻿using Aer.QdrantClient.Http;
+using Aer.QdrantClient.Http.Configuration;
 using Aer.QdrantClient.Http.Exceptions;
 using Aer.QdrantClient.Http.Models.Requests.Public;
 using Aer.QdrantClient.Http.Models.Responses;
@@ -10,12 +11,14 @@ namespace Aer.QdrantClient.Tests.TestClasses.HttpClientTests.Snapshots;
 public class CollectionSnapshotTestsSingleNode : SnapshotTestsBase
 {
     private QdrantHttpClient _qdrantHttpClientSingleNode;
+    private QdrantClientSettings _clientSettings;
 
     [OneTimeSetUp]
     public void Setup()
     {
         Initialize();
 
+        _clientSettings = GetQdrantClientSettings();
         _qdrantHttpClientSingleNode = ServiceProvider.GetRequiredService<QdrantHttpClient>();
     }
 
@@ -158,6 +161,7 @@ public class CollectionSnapshotTestsSingleNode : SnapshotTestsBase
         snapshotInfo.Name.Should().Be(createFirstSnapshotResult.Name);
         snapshotInfo.Size.Should().Be(createFirstSnapshotResult.Size);
         snapshotInfo.SizeMegabytes.Should().Be(createFirstSnapshotResult.SizeMegabytes);
+        
         snapshotInfo.CreationTime.Should().Be(createFirstSnapshotResult.CreationTime);
         snapshotInfo.Checksum.Should().Be(createFirstSnapshotResult.Checksum);
         snapshotInfo.SnapshotType.Should().Be(SnapshotType.Collection);
@@ -295,7 +299,12 @@ public class CollectionSnapshotTestsSingleNode : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
 
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 
@@ -351,7 +360,12 @@ public class CollectionSnapshotTestsSingleNode : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
 
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
+        
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/ShardSnapshotTests.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/ShardSnapshotTests.cs
@@ -1,4 +1,5 @@
 ﻿using Aer.QdrantClient.Http;
+using Aer.QdrantClient.Http.Configuration;
 using Aer.QdrantClient.Http.Exceptions;
 using Aer.QdrantClient.Http.Models.Requests.Public;
 using Aer.QdrantClient.Http.Models.Responses;
@@ -12,6 +13,7 @@ public class ShardSnapshotTests : SnapshotTestsBase
     // NOTE: since we don't have a cluster in test and thus have only one shard
     // these tests basically repeat the tests from CollectionSnapshotTests but using shard methods
     private QdrantHttpClient _qdrantHttpClient;
+    private QdrantClientSettings _clientSettings;
 
     // since we don't have a cluster in test and thus have only one shard which is always 0
     private const int SINGLE_SHARD_ID = 0;
@@ -20,6 +22,8 @@ public class ShardSnapshotTests : SnapshotTestsBase
     public void Setup()
     {
         Initialize();
+        
+        _clientSettings = GetQdrantClientSettings();
         _qdrantHttpClient = ServiceProvider.GetRequiredService<QdrantHttpClient>();
     }
 
@@ -297,7 +301,12 @@ public class ShardSnapshotTests : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
 
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 
@@ -350,7 +359,12 @@ public class ShardSnapshotTests : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
 
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
+
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/StorageSnapshotTests.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Snapshots/StorageSnapshotTests.cs
@@ -1,4 +1,5 @@
 ﻿using Aer.QdrantClient.Http;
+using Aer.QdrantClient.Http.Configuration;
 using Aer.QdrantClient.Http.Models.Responses;
 using Aer.QdrantClient.Http.Models.Shared;
 using Aer.QdrantClient.Tests.Model;
@@ -8,12 +9,14 @@ namespace Aer.QdrantClient.Tests.TestClasses.HttpClientTests.Snapshots;
 public class StorageSnapshotTests : SnapshotTestsBase
 {
     private QdrantHttpClient _qdrantHttpClient;
+    private QdrantClientSettings _clientSettings;
 
     [OneTimeSetUp]
     public void Setup()
     {
         Initialize();
-
+        
+        _clientSettings = GetQdrantClientSettings();
         _qdrantHttpClient = ServiceProvider.GetRequiredService<QdrantHttpClient>();
     }
 
@@ -204,7 +207,12 @@ public class StorageSnapshotTests : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
 
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 
@@ -233,7 +241,12 @@ public class StorageSnapshotTests : SnapshotTestsBase
 
         downloadSnapshotResponse.Status.IsSuccess.Should().BeTrue();
         downloadSnapshotResponse.Result.SnapshotName.Should().Be(createSnapshotResult.Name);
-        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(createSnapshotResult.Size);
+
+        downloadSnapshotResponse.Result.SnapshotSizeBytes.Should().Be(
+            !_clientSettings.EnableCompression
+                ? createSnapshotResult.Size
+                : 0
+        );
 
         downloadSnapshotResponse.Result.SnapshotDataStream.Should().NotBeNull();
 

--- a/tests/Aer.QdrantClient.Tests/appsettings.json
+++ b/tests/Aer.QdrantClient.Tests/appsettings.json
@@ -2,6 +2,8 @@
     "QdrantClientSettings": {
         "HttpAddress": "http://localhost:6333",
         "ApiKey": "test",
-        "HttpClientTimeout" : "00:10:00"
+        "HttpClientTimeout" : "00:10:00",
+        "DisableTracing": false,
+        "EnableCompression": true
     }
 }


### PR DESCRIPTION
- Reduced `Payload` memory footprint. Now `Payload` only holds a json string unless asked for `Payload.RawPayload` JsonObject .
Added HTTP compression support;
- Added more options to `QdrantClientSettings`. Now all options are supported.
- **Breaking change :** `QdrantClientSettings` no longer registered as a concrete type singleton when using `IServiceCollection.AddQdrantHttpClient` methods.