### PR TITLE
Feature/more improved replicator

### DIFF
--- a/src/Aer.QdrantClient.Http/Helpers/NetstandardPolyfill/NetstandardExtensions.cs
+++ b/src/Aer.QdrantClient.Http/Helpers/NetstandardPolyfill/NetstandardExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 
 namespace Aer.QdrantClient.Http.Helpers.NetstandardPolyfill;
@@ -10,6 +11,11 @@ internal static class HttpResponseMessageExtensions
 
     extension<TSource>(IEnumerable<TSource> source)
     {
+        public IOrderedEnumerable<TSource> Order()
+        {
+            return source.OrderBy(x => x);
+        }
+
         public bool TryGetNonEnumeratedCount(out int count)
         {
             if (source is null)
@@ -209,6 +215,17 @@ internal static class HttpResponseMessageExtensions
             }
 
             return value;
+        }
+    }
+
+    extension<T>(ConcurrentQueue<T> source)
+    {
+        public void Clear()
+        {
+            while (!source.IsEmpty)
+            {
+                source.TryDequeue(out _);
+            }
         }
     }
 

--- a/src/Aer.QdrantClient.Http/Infrastructure/Replication/CollectionClusteringState.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Replication/CollectionClusteringState.cs
@@ -8,7 +8,7 @@ namespace Aer.QdrantClient.Http.Infrastructure.Replication;
 /// <summary>
 /// Represents a collection clustering state, either current, in the past or in the future.
 /// </summary>
-internal class CollectionClusteringState
+internal class CollectionClusteringState : IEquatable<CollectionClusteringState>
 {
     /// <summary>
     /// Represents a cluster peer.
@@ -104,6 +104,20 @@ internal class CollectionClusteringState
         MinNumberOfReplicasPerPeer = (int)Math.Floor(expectedNumberOfReplicasPerPeer);
     }
 
+    private CollectionClusteringState(CollectionClusteringState source)
+    {
+        KnownPeers = new Dictionary<ulong, Peer>(source.KnownPeers);
+
+        ShardsByPeers = source.ShardsByPeers.ToDictionary(kvp => kvp.Key, kvp => new HashSet<uint>(kvp.Value));
+
+        PeersByShards = source.PeersByShards.ToDictionary(kvp => kvp.Key, kvp => new HashSet<ulong>(kvp.Value));
+
+        ShardCount = source.ShardCount;
+        MaxNumberOfReplicasPerPeer = source.MaxNumberOfReplicasPerPeer;
+        MinNumberOfReplicasPerPeer = source.MinNumberOfReplicasPerPeer;
+        Version = source.Version;
+    }
+
     public bool AddShardReplica(uint shardId, ulong newPeerId, bool shouldUpdateVersion = true)
     {
         bool wasStateModified = false;
@@ -159,6 +173,7 @@ internal class CollectionClusteringState
         // We are passing `shouldUpdateVersion: false` to each of the operations to only update version once
 
         wasStateModified |= DropShardReplica(shardId, sourcePeerId, shouldUpdateVersion: false);
+
         wasStateModified |= AddShardReplica(shardId, targetPeerId, shouldUpdateVersion: false);
 
         if (wasStateModified)
@@ -195,9 +210,9 @@ internal class CollectionClusteringState
     public (ulong PeerId, HashSet<uint> ShardIds)? GetMostOverpopulatedPeer()
     {
         var overpopulatedPeer = ShardsByPeers
-                .Where(peerWithShards => peerWithShards.Value.Count > MaxNumberOfReplicasPerPeer)
-                .OrderByDescending(p => p.Value.Count)
-                .FirstOrDefault();
+            .Where(peerWithShards => peerWithShards.Value.Count > MaxNumberOfReplicasPerPeer)
+            .OrderByDescending(p => p.Value.Count)
+            .FirstOrDefault();
 
         if (overpopulatedPeer.Key == 0 && overpopulatedPeer.Value == null)
         {
@@ -211,9 +226,9 @@ internal class CollectionClusteringState
     public (ulong PeerId, HashSet<uint> ShardIds)? GetMostUnderpopulatedPeer()
     {
         var underpopulatedPeer = ShardsByPeers
-                .Where(peerWithShards => peerWithShards.Value.Count < MinNumberOfReplicasPerPeer)
-                .OrderBy(p => p.Value.Count)
-                .FirstOrDefault();
+            .Where(peerWithShards => peerWithShards.Value.Count < MinNumberOfReplicasPerPeer)
+            .OrderBy(p => p.Value.Count)
+            .FirstOrDefault();
 
         if (underpopulatedPeer.Key == 0 && underpopulatedPeer.Value == null)
         {
@@ -222,6 +237,111 @@ internal class CollectionClusteringState
         }
 
         return (underpopulatedPeer.Key, underpopulatedPeer.Value);
+    }
+
+    public CollectionClusteringState Clone() => new(this);
+
+    public bool Equals(CollectionClusteringState other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (
+            ShardCount != other.ShardCount
+            || MaxNumberOfReplicasPerPeer != other.MaxNumberOfReplicasPerPeer
+            || MinNumberOfReplicasPerPeer != other.MinNumberOfReplicasPerPeer
+        )
+        {
+            return false;
+        }
+
+        if (
+            KnownPeers.Count != other.KnownPeers.Count
+            || ShardsByPeers.Count != other.ShardsByPeers.Count
+            || PeersByShards.Count != other.PeersByShards.Count
+        )
+        {
+            return false;
+        }
+
+        foreach (var (peerId, peer) in KnownPeers)
+        {
+            if (!other.KnownPeers.TryGetValue(peerId, out var otherPeer) || !peer.Equals(otherPeer))
+            {
+                return false;
+            }
+        }
+
+        foreach (var (peerId, shards) in ShardsByPeers)
+        {
+            if (!other.ShardsByPeers.TryGetValue(peerId, out var otherShards) || !shards.SetEquals(otherShards))
+            {
+                return false;
+            }
+        }
+
+        foreach (var (shardId, peers) in PeersByShards)
+        {
+            if (!other.PeersByShards.TryGetValue(shardId, out var otherPeers) || !peers.SetEquals(otherPeers))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object obj) => obj is CollectionClusteringState other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+
+        hash.Add(ShardCount);
+        hash.Add(MaxNumberOfReplicasPerPeer);
+        hash.Add(MinNumberOfReplicasPerPeer);
+
+        foreach (var (peerId, shards) in ShardsByPeers)
+        {
+            hash.Add(peerId);
+            foreach (var shardId in shards.Order())
+            {
+                hash.Add(shardId);
+            }
+        }
+
+        foreach (var (shardId, peers) in PeersByShards)
+        {
+            hash.Add(shardId);
+            foreach (var peerId in peers.Order())
+            {
+                hash.Add(peerId);
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+    {
+        var shardsByPeers = string.Join(
+            ", ",
+            ShardsByPeers.Select(kvp => $"{kvp.Key}:[{string.Join(",", kvp.Value.Order())}]")
+        );
+
+        var peersByShards = string.Join(
+            ", ",
+            PeersByShards.Select(kvp => $"{kvp.Key}:[{string.Join(",", kvp.Value.Order())}]")
+        );
+
+        return $"Shards:{ShardCount} MinReplicas:{MinNumberOfReplicasPerPeer} MaxReplicas:{MaxNumberOfReplicasPerPeer} v{Version} ShardsByPeers={{{shardsByPeers}}} PeersByShards={{{peersByShards}}}";
     }
 }
 

--- a/src/Aer.QdrantClient.Http/Infrastructure/Replication/CollectionClusteringState.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Replication/CollectionClusteringState.cs
@@ -17,9 +17,6 @@ internal class CollectionClusteringState
     /// <param name="Uri">The peer URI.</param>
     internal record Peer(ulong Id, string Uri);
 
-    //private int _version;
-    private readonly int _targetReplicationFactor;
-
     /// <summary>
     /// Gets the mapping of peer identifiers to the list of shard identifiers replicated on them .
     /// </summary>
@@ -40,8 +37,14 @@ internal class CollectionClusteringState
     /// </summary>
     public int ShardCount { get; }
 
+    /// <summary>
+    /// Maximal allowed number of replicas per shard.
+    /// </summary>
     public int MaxNumberOfReplicasPerPeer { get; }
 
+    /// <summary>
+    /// Minimal allowed number of replicas per shard.
+    /// </summary>
     public int MinNumberOfReplicasPerPeer { get; }
 
     /// <summary>
@@ -94,8 +97,6 @@ internal class CollectionClusteringState
         }
 
         ShardCount = allShardIds.Count;
-
-        _targetReplicationFactor = targetReplicationFactor;
 
         var expectedNumberOfReplicasPerPeer = (double)targetReplicationFactor * ShardCount / KnownPeers.Count;
 

--- a/src/Aer.QdrantClient.Http/Infrastructure/Replication/ScheduledShardReplication.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Replication/ScheduledShardReplication.cs
@@ -30,6 +30,8 @@ public record ScheduledShardReplication(
     int StepNumber
 )
 {
+    internal CollectionClusteringState ExpectedInitialState { get; set; }
+
     /// <summary>
     /// The action that the replicator will perform on selected shard.
     /// </summary>

--- a/src/Aer.QdrantClient.Http/Infrastructure/Replication/ShardReplicator.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Replication/ShardReplicator.cs
@@ -27,6 +27,8 @@ public class ShardReplicator
     private readonly ILogger _logger;
     private readonly string _collectionName;
     private int _targetReplicationFactor;
+    // The shards that replicator is forbidden to perform any operations on
+    private readonly HashSet<uint> _skippedShards = [];
 
     // Probably concurrent queue is an overkill here
     private ConcurrentQueue<ScheduledShardReplication> _shardReplicationsToExecute;
@@ -72,11 +74,37 @@ public class ShardReplicator
         //List<(uint ShardId, int NumberOfReplicasToAdd)> shardsToReplicate = [with(collectionClusteringInfo.PeersByShards.Count)];
         //List<(uint ShardId, int NumberOfReplicasToDrop)> shardsToDrop = [with(collectionClusteringInfo.PeersByShards.Count)];
 
-        // Collect shards with unbalanced replicas
+        // Check actual number of replicas for each shard against required replication factor
+
+        List<(uint ShardId, ulong PeerId)> inactiveShardReplicasToDrop = [];
 
         foreach (var (shardId, peerIds) in collectionClusteringInfo.PeersByShards)
         {
-            switch (peerIds.Count.CompareTo(_targetReplicationFactor))
+            int inactiveReplicaCount = 0;
+
+            foreach (var peerId in peerIds)
+            {
+                var peerState = collectionClusteringInfo.ShardStates[shardId][peerId];
+
+                if (peerState is not (ShardState.Active or ShardState.ActiveRead))
+                {
+                    // We should add inactive replicas to the drop list only
+                    // If any other active replica exists for them
+                    inactiveShardReplicasToDrop.Add((shardId, peerId));
+                    inactiveReplicaCount++;
+                }
+            }
+
+            if (inactiveReplicaCount == peerIds.Count)
+            {
+                // Means all replicas for this shard are in inactive state. We don't have any means to copy active data.
+                // Don't perform any operations on that shard
+                _skippedShards.Add(shardId);
+
+                continue;
+            }
+
+            switch ((peerIds.Count - inactiveReplicaCount).CompareTo(_targetReplicationFactor))
             {
                 case 0:
                     // shard is replicated expected number of times
@@ -84,13 +112,12 @@ public class ShardReplicator
                     break;
 
                 case > 0:
-                    // shard is replicated more times than expected
-                    // Do nothing - for now at least
+                    // shard is replicated more times than expected - drop extra replicas
                     shardsToDrop.Add((shardId, peerIds.Count - _targetReplicationFactor));
                     break;
 
                 case < 0:
-                    // shard is replicated fewer times than expected
+                    // shard is replicated fewer times than expected - add more replicas
                     shardsToReplicate.Add((shardId, _targetReplicationFactor - peerIds.Count));
                     break;
             }
@@ -126,6 +153,7 @@ public class ShardReplicator
         // Plan shard replications
 
         var targetCollectionClusteringState = PlanReplications(
+            inactiveShardReplicasToDrop,
             shardsToReplicate,
             shardsToDrop,
             clusterInfo,
@@ -136,6 +164,7 @@ public class ShardReplicator
     }
 
     private CollectionClusteringState PlanReplications(
+        List<(uint ShardId, ulong PeerId)> inactiveShardReplicas,
         List<(uint ShardId, int NumberOfReplicasToAdd)> shardsToReplicate,
         List<(uint ShardId, int NumberOfReplicasToDrop)> shardsToDrop,
         GetClusterInfoResponse.ClusterInfo clusterInfo,
@@ -156,25 +185,65 @@ public class ShardReplicator
             _targetReplicationFactor
         );
 
-        // 0. Drop extra replicas
+        // 0. Drop inactive replicas. We consider replica inactive if it is not Active.
+
+        PlanInactiveReplicaDrops(inactiveShardReplicas, collectionClusteringState);
+
+        // 1. Drop extra replicas
 
         PlanExtraReplicaDrops(shardsToDrop, collectionClusteringState);
 
-        // 1. Replicate shards that don't have enough replicas
+        // 2. Replicate shards that don't have enough replicas
 
         PlanAddingReplicas(shardsToReplicate, collectionClusteringState);
 
-        // 2. Move shards until collection is balanced. I.e. there are no overpopulated or underpopulated peers.
+        // 3. Move shards until collection is balanced. I.e. there are no overpopulated or underpopulated peers.
 
-        // 2.1 - check overpopulated peers and depopulate them
+        // 3.1 - check overpopulated peers and depopulate them
 
         PlanOverpopulationFix(collectionClusteringState);
 
-        // 2.2 - check underpopulated peers and populate them
+        // 3.2 - check underpopulated peers and populate them
 
         PlanUnderpopulationFix(collectionClusteringState);
 
         return collectionClusteringState;
+    }
+
+    private void PlanInactiveReplicaDrops(
+        List<(uint ShardId, ulong PeerId)> inactiveShardReplicasToDrop,
+        CollectionClusteringState collectionClusteringState)
+    {
+        if (inactiveShardReplicasToDrop is { Count: > 0 })
+        {
+            foreach (var (shardIdToDrop, peerToDropShardFrom) in inactiveShardReplicasToDrop)
+            {
+                if (_skippedShards.Contains(shardIdToDrop))
+                {
+                    continue;
+                }
+
+                if (!collectionClusteringState.DropShardReplica(shardIdToDrop, peerToDropShardFrom))
+                {
+                    throw new InvalidOperationException(
+                        $"Invalid algorithm state. Shard {shardIdToDrop} inactive replica drop from peer {peerToDropShardFrom} can't be performed"
+                    );
+                }
+
+                // Here target peer uri and url are null since we are dropping the replica
+                _shardReplicationsToExecute.Enqueue(
+                    new(
+                        shardIdToDrop,
+                        SourcePeerId: shardIdToDrop,
+                        SourcePeerUri: collectionClusteringState.KnownPeers[shardIdToDrop].Uri,
+                        TargetPeerId: null,
+                        TargetPeerUri: null,
+                        ScheduledShardReplication.ReplicatorAction.DropReplica,
+                        collectionClusteringState.Version
+                    )
+                );
+            }
+        }
     }
 
     private void PlanExtraReplicaDrops(
@@ -186,6 +255,11 @@ public class ShardReplicator
         {
             foreach (var (shardIdToDrop, replicasToDrop) in shardsToDrop)
             {
+                if (_skippedShards.Contains(shardIdToDrop))
+                {
+                    continue;
+                }
+
                 int replicasLeftToDrop = replicasToDrop;
 
                 while (replicasLeftToDrop > 0)
@@ -217,7 +291,7 @@ public class ShardReplicator
                     if (!collectionClusteringState.DropShardReplica(shardIdToDrop, selectedPeerId))
                     {
                         throw new InvalidOperationException(
-                            $"Invalid algorithm state. Shard {shardIdToDrop} drop from peer {selectedPeerId}() can't be performed"
+                            $"Invalid algorithm state. Shard {shardIdToDrop} drop from peer {selectedPeerId} can't be performed"
                         );
                     }
 
@@ -249,6 +323,11 @@ public class ShardReplicator
         {
             foreach (var (shardIdToReplicate, replicasToAdd) in shardsToReplicate)
             {
+                if (_skippedShards.Contains(shardIdToReplicate))
+                {
+                    continue;
+                }
+
                 // Select target peers which do not have specified shard replica
                 var targetPeerIds = collectionClusteringState
                     .ShardsByPeers.Where(kv => !kv.Value.Contains(shardIdToReplicate))
@@ -410,6 +489,45 @@ public class ShardReplicator
     }
 
     /// <summary>
+    /// Asynchronously executed the next replication from a <see cref="ReplicationPlan"/> and returns its result.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// A cancellation token that can be used to cancel the asynchronous replication operation.
+    /// </param>
+    /// <param name="shardTransferMethod">
+    /// The method used to transfer the shard to the target peer.
+    /// Defaults to <see cref="ShardTransferMethod.Snapshot"/> if not specified.
+    /// </param>
+    /// <param name="timeout">
+    /// An optional timeout that specifies the maximum duration
+    /// to wait for a replication operation.
+    /// If not provided, the default timeout of 30 seconds is used.</param>
+    /// <remarks>
+    /// It is recommended to check on the returned replication status
+    /// before continuing with the next replication step.
+    /// </remarks>
+    public Task<ReplicateShardsToPeerResponse> ExecuteNextReplication(
+        CancellationToken cancellationToken,
+        ShardTransferMethod shardTransferMethod = ShardTransferMethod.Snapshot,
+        TimeSpan? timeout = null
+    )
+    {
+        if (_shardReplicationsToExecute is null or { IsEmpty: true })
+        {
+            return Task.FromResult(
+                ReplicateShardsToPeerResponse.Fail(
+                    QdrantStatus.Fail("No replications to execute"),
+                    time: 0
+                )
+            );
+        }
+
+        _shardReplicationsToExecute.TryDequeue(out var nextReplicationStep);
+
+        return ExecuteNextReplicationInternal(nextReplicationStep, shardTransferMethod, timeout, cancellationToken);
+    }
+
+    /// <summary>
     /// Asynchronously replicates the specified shards to target peers.
     /// </summary>
     /// <param name="cancellationToken">
@@ -448,192 +566,200 @@ public class ShardReplicator
 
             _shardReplicationsToExecute.TryDequeue(out var nextReplicationStep);
 
-            var (shardId, sourcePeerId, _, targetPeerId, _, replicatorAction, _) = nextReplicationStep;
+            var shardReplicationResult = await ExecuteNextReplicationInternal(nextReplicationStep, shardTransferMethod, timeout, cancellationToken);
 
-            switch (replicatorAction)
+            yield return shardReplicationResult;
+        }
+    }
+
+    private async Task<ReplicateShardsToPeerResponse> ExecuteNextReplicationInternal(
+        ScheduledShardReplication nextReplicationStep,
+        ShardTransferMethod shardTransferMethod,
+        TimeSpan? timeout,
+        CancellationToken cancellationToken
+    )
+    {
+        var (shardId, sourcePeerId, _, targetPeerId, _, replicatorAction, _) = nextReplicationStep;
+
+        switch (replicatorAction)
+        {
+            case ScheduledShardReplication.ReplicatorAction.AddReplica:
             {
-                case ScheduledShardReplication.ReplicatorAction.AddReplica:
+                var replicateShardStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
+                    _collectionName,
+                    UpdateCollectionClusteringSetupRequest.CreateReplicateShardRequest(
+                        shardId,
+                        sourcePeerId,
+                        targetPeerId.Value,
+                        shardTransferMethod
+                    ),
+                    cancellationToken,
+                    timeout
+                );
+
+                ReplicateShardsToPeerResponse replicateShardResponse;
+
+                if (replicateShardStartResponse.Status.IsSuccess)
                 {
-                    var replicateShardStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
-                        _collectionName,
-                        UpdateCollectionClusteringSetupRequest.CreateReplicateShardRequest(
-                            shardId,
-                            sourcePeerId,
-                            targetPeerId.Value,
-                            shardTransferMethod
+                    replicateShardResponse = new ReplicateShardsToPeerResponse()
+                    {
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                                        IsSuccess: true,
+                                        ShardId: shardId,
+                                        SourcePeerId: sourcePeerId,
+                                        TargetPeerId: targetPeerId,
+                                        _collectionName
+                                    ),
+                            ],
+                            AlreadyReplicatedShards: []
                         ),
-                        cancellationToken,
-                        timeout
-                    );
-
-                    ReplicateShardsToPeerResponse replicateShardResponse;
-
-                    if (replicateShardStartResponse.Status.IsSuccess)
+                        Status = QdrantStatus.Success(),
+                        Time = replicateShardStartResponse.Time,
+                    };
+                }
+                else
+                {
+                    replicateShardResponse = new ReplicateShardsToPeerResponse(replicateShardStartResponse)
                     {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse()
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
-                                        IsSuccess: true,
-                                        ShardId: shardId,
-                                        SourcePeerId: sourcePeerId,
-                                        TargetPeerId: targetPeerId,
-                                        _collectionName
-                                    ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                            Status = QdrantStatus.Success(),
-                            Time = replicateShardStartResponse.Time,
-                        };
-                    }
-                    else
-                    {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse(replicateShardStartResponse)
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
                                         IsSuccess: false,
                                         ShardId: shardId,
                                         SourcePeerId: sourcePeerId,
                                         TargetPeerId: targetPeerId,
                                         _collectionName
                                     ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                        };
-                    }
-
-                    yield return replicateShardResponse;
-
-                    break;
-                }
-
-                case ScheduledShardReplication.ReplicatorAction.DropReplica:
-                {
-                    var dropShardReplicaStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
-                        _collectionName,
-                        UpdateCollectionClusteringSetupRequest.CreateDropShardReplicaRequest(shardId, sourcePeerId),
-                        cancellationToken,
-                        timeout
-                    );
-
-                    ReplicateShardsToPeerResponse replicateShardResponse;
-
-                    if (dropShardReplicaStartResponse.Status.IsSuccess)
-                    {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse()
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
-                                        IsSuccess: true,
-                                        ShardId: shardId,
-                                        SourcePeerId: sourcePeerId,
-                                        TargetPeerId: null,
-                                        _collectionName
-                                    ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                            Status = QdrantStatus.Success(),
-                            Time = dropShardReplicaStartResponse.Time,
-                        };
-                    }
-                    else
-                    {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse(dropShardReplicaStartResponse)
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
-                                        IsSuccess: false,
-                                        ShardId: shardId,
-                                        SourcePeerId: sourcePeerId,
-                                        TargetPeerId: null,
-                                        _collectionName
-                                    ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                        };
-                    }
-
-                    yield return replicateShardResponse;
-
-                    break;
-                }
-                case ScheduledShardReplication.ReplicatorAction.MoveReplica:
-                {
-                    var moveShardStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
-                        _collectionName,
-                        UpdateCollectionClusteringSetupRequest.CreateMoveShardRequest(
-                            shardId,
-                            sourcePeerId,
-                            targetPeerId.Value,
-                            shardTransferMethod
+                            ],
+                            AlreadyReplicatedShards: []
                         ),
-                        cancellationToken,
-                        timeout
-                    );
-
-                    ReplicateShardsToPeerResponse replicateShardResponse;
-
-                    if (moveShardStartResponse.Status.IsSuccess)
-                    {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse()
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
-                                        IsSuccess: true,
-                                        ShardId: shardId,
-                                        SourcePeerId: sourcePeerId,
-                                        TargetPeerId: targetPeerId,
-                                        _collectionName
-                                    ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                            Status = QdrantStatus.Success(),
-                            Time = moveShardStartResponse.Time,
-                        };
-                    }
-                    else
-                    {
-                        replicateShardResponse = new ReplicateShardsToPeerResponse(moveShardStartResponse)
-                        {
-                            Result = new(
-                                ReplicatedShards:
-                                [
-                                    new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
-                                        IsSuccess: false,
-                                        ShardId: shardId,
-                                        SourcePeerId: sourcePeerId,
-                                        TargetPeerId: targetPeerId,
-                                        _collectionName
-                                    ),
-                                ],
-                                AlreadyReplicatedShards: []
-                            ),
-                        };
-                    }
-
-                    yield return replicateShardResponse;
-
-                    break;
+                    };
                 }
-                default:
-                    throw new InvalidOperationException($"Unknown replicator action {replicatorAction}");
+
+                return replicateShardResponse;
             }
+
+            case ScheduledShardReplication.ReplicatorAction.DropReplica:
+            {
+                var dropShardReplicaStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
+                    _collectionName,
+                    UpdateCollectionClusteringSetupRequest.CreateDropShardReplicaRequest(shardId, sourcePeerId),
+                    cancellationToken,
+                    timeout
+                );
+
+                ReplicateShardsToPeerResponse replicateShardResponse;
+
+                if (dropShardReplicaStartResponse.Status.IsSuccess)
+                {
+                    replicateShardResponse = new ReplicateShardsToPeerResponse()
+                    {
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                                        IsSuccess: true,
+                                        ShardId: shardId,
+                                        SourcePeerId: sourcePeerId,
+                                        TargetPeerId: null,
+                                        _collectionName
+                                    ),
+                            ],
+                            AlreadyReplicatedShards: []
+                        ),
+                        Status = QdrantStatus.Success(),
+                        Time = dropShardReplicaStartResponse.Time,
+                    };
+                }
+                else
+                {
+                    replicateShardResponse = new ReplicateShardsToPeerResponse(dropShardReplicaStartResponse)
+                    {
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                                        IsSuccess: false,
+                                        ShardId: shardId,
+                                        SourcePeerId: sourcePeerId,
+                                        TargetPeerId: null,
+                                        _collectionName
+                                    ),
+                            ],
+                            AlreadyReplicatedShards: []
+                        ),
+                    };
+                }
+
+                return replicateShardResponse;
+            }
+
+            case ScheduledShardReplication.ReplicatorAction.MoveReplica:
+            {
+                var moveShardStartResponse = await _qdrantClient.UpdateCollectionClusteringSetup(
+                    _collectionName,
+                    UpdateCollectionClusteringSetupRequest.CreateMoveShardRequest(
+                        shardId,
+                        sourcePeerId,
+                        targetPeerId.Value,
+                        shardTransferMethod
+                    ),
+                    cancellationToken,
+                    timeout
+                );
+
+                ReplicateShardsToPeerResponse replicateShardResponse;
+
+                if (moveShardStartResponse.Status.IsSuccess)
+                {
+                    replicateShardResponse = new ReplicateShardsToPeerResponse()
+                    {
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                                        IsSuccess: true,
+                                        ShardId: shardId,
+                                        SourcePeerId: sourcePeerId,
+                                        TargetPeerId: targetPeerId,
+                                        _collectionName
+                                    ),
+                            ],
+                            AlreadyReplicatedShards: []
+                        ),
+                        Status = QdrantStatus.Success(),
+                        Time = moveShardStartResponse.Time,
+                    };
+                }
+                else
+                {
+                    replicateShardResponse = new ReplicateShardsToPeerResponse(moveShardStartResponse)
+                    {
+                        Result = new(
+                            ReplicatedShards:
+                            [
+                                new ReplicateShardsToPeerResponse.ReplicateShardToPeerResult(
+                                        IsSuccess: false,
+                                        ShardId: shardId,
+                                        SourcePeerId: sourcePeerId,
+                                        TargetPeerId: targetPeerId,
+                                        _collectionName
+                                    ),
+                            ],
+                            AlreadyReplicatedShards: []
+                        ),
+                    };
+                }
+
+                return replicateShardResponse;
+            }
+
+            default:
+                throw new InvalidOperationException($"Unknown replicator action {replicatorAction}");
         }
     }
 

--- a/src/Aer.QdrantClient.Http/Infrastructure/Replication/ShardReplicator.cs
+++ b/src/Aer.QdrantClient.Http/Infrastructure/Replication/ShardReplicator.cs
@@ -1,11 +1,11 @@
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using Aer.QdrantClient.Http.Collections;
 using Aer.QdrantClient.Http.Helpers.NetstandardPolyfill;
 using Aer.QdrantClient.Http.Models.Requests;
 using Aer.QdrantClient.Http.Models.Responses;
 using Aer.QdrantClient.Http.Models.Shared;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace Aer.QdrantClient.Http.Infrastructure.Replication;
 
@@ -26,6 +26,7 @@ public class ShardReplicator
     private readonly QdrantHttpClient _qdrantClient;
     private readonly ILogger _logger;
     private readonly string _collectionName;
+    private readonly string _clusterName;
     private int _targetReplicationFactor;
     // The shards that replicator is forbidden to perform any operations on
     private readonly HashSet<uint> _skippedShards = [];
@@ -49,19 +50,33 @@ public class ShardReplicator
     /// </summary>
     public IReadOnlyCollection<ScheduledShardReplication> ReplicationPlan => _shardReplicationsToExecute ?? [];
 
-    internal ShardReplicator(QdrantHttpClient qdrantClient, ILogger logger, string collectionName)
+    internal ShardReplicator(QdrantHttpClient qdrantClient, ILogger logger, string collectionName, string clusterName)
     {
         _qdrantClient = qdrantClient;
         _logger = logger;
         _collectionName = collectionName;
+        _clusterName = clusterName;
     }
 
-    internal void Calculate(
+    // We call calculate with initial collection and cluster state. We assume that it won't change by any means apart from shard treplicator itself.
+    // On each replication step we check that this invariant is held true.
+    internal RestoreShardReplicationFactorResponse Calculate(
         GetClusterInfoResponse.ClusterInfo clusterInfo,
         GetCollectionInfoResponse.CollectionInfo collectionInfo,
         GetCollectionClusteringInfoResponse.CollectionClusteringInfo collectionClusteringInfo
     )
     {
+        if (collectionClusteringInfo.ShardTransfers.Length > 0)
+        {
+            // We don't allow starting any replication-related operations while there are any ongoing shard transfers
+
+            return new RestoreShardReplicationFactorResponse()
+            {
+                Result = null,
+                Status = QdrantStatus.Fail($"Can't restore shard replication factor. Found {collectionClusteringInfo.ShardTransfers} ongoing shard transfers. To ensure that collection data is not corrupted, wait for ongoing shard transfers to finish and start restore shard replication factor process again.")
+            };
+        }
+
         _targetReplicationFactor = GetCollectionReplicationFactor(collectionInfo, collectionClusteringInfo);
 
         // Check that each shard is replicated no fewer than targetCollectionReplicationFactor of times
@@ -161,6 +176,12 @@ public class ShardReplicator
         );
 
         _targetCollectionClusteringState = targetCollectionClusteringState;
+
+        return new RestoreShardReplicationFactorResponse()
+        {
+            Result = this,
+            Status = QdrantStatus.Success()
+        };
     }
 
     private CollectionClusteringState PlanReplications(
@@ -223,6 +244,8 @@ public class ShardReplicator
                     continue;
                 }
 
+                var expectedStateBeforeReplication = collectionClusteringState.Clone();
+
                 if (!collectionClusteringState.DropShardReplica(shardIdToDrop, peerToDropShardFrom))
                 {
                     throw new InvalidOperationException(
@@ -241,6 +264,9 @@ public class ShardReplicator
                         ScheduledShardReplication.ReplicatorAction.DropReplica,
                         collectionClusteringState.Version
                     )
+                    {
+                        ExpectedInitialState = expectedStateBeforeReplication
+                    }
                 );
             }
         }
@@ -288,6 +314,8 @@ public class ShardReplicator
                         );
                     }
 
+                    var expectedStateBeforeReplication = collectionClusteringState.Clone();
+
                     if (!collectionClusteringState.DropShardReplica(shardIdToDrop, selectedPeerId))
                     {
                         throw new InvalidOperationException(
@@ -306,6 +334,9 @@ public class ShardReplicator
                             ScheduledShardReplication.ReplicatorAction.DropReplica,
                             collectionClusteringState.Version
                         )
+                        {
+                            ExpectedInitialState = expectedStateBeforeReplication
+                        }
                     );
 
                     replicasLeftToDrop--;
@@ -353,6 +384,8 @@ public class ShardReplicator
                     var targetPeerId = targetPeers.GetNext();
                     var targetPeerUri = collectionClusteringState.KnownPeers[targetPeerId].Uri;
 
+                    var expectedStateBeforeReplication = collectionClusteringState.Clone();
+
                     if (!collectionClusteringState.AddShardReplica(shardIdToReplicate, targetPeerId))
                     {
                         throw new InvalidOperationException(
@@ -370,6 +403,9 @@ public class ShardReplicator
                             ScheduledShardReplication.ReplicatorAction.AddReplica,
                             collectionClusteringState.Version
                         )
+                        {
+                            ExpectedInitialState = expectedStateBeforeReplication
+                        }
                     );
 
                     replicasLeftToAdd--;
@@ -395,6 +431,8 @@ public class ShardReplicator
                     var sourcePeerId = overpopulatedPeer.Value.PeerId;
                     var targetPeerId = minReplicasPeerId;
 
+                    var expectedStateBeforeReplication = collectionClusteringState.Clone();
+
                     if (!collectionClusteringState.MoveShardReplica(shardIdToMove, sourcePeerId, targetPeerId))
                     {
                         throw new InvalidOperationException(
@@ -412,6 +450,9 @@ public class ShardReplicator
                             ScheduledShardReplication.ReplicatorAction.MoveReplica,
                             collectionClusteringState.Version
                         )
+                        {
+                            ExpectedInitialState = expectedStateBeforeReplication
+                        }
                     );
 
                     foundShardToMove = true;
@@ -451,6 +492,8 @@ public class ShardReplicator
                     var sourcePeerId = maxReplicasPeerId;
                     var targetPeerId = underpopulatedPeer.Value.PeerId;
 
+                    var expectedStateBeforeReplication = collectionClusteringState.Clone();
+
                     if (!collectionClusteringState.MoveShardReplica(shardIdToMove, sourcePeerId, targetPeerId))
                     {
                         throw new InvalidOperationException(
@@ -468,6 +511,9 @@ public class ShardReplicator
                             ScheduledShardReplication.ReplicatorAction.MoveReplica,
                             collectionClusteringState.Version
                         )
+                        {
+                            ExpectedInitialState = expectedStateBeforeReplication
+                        }
                     );
 
                     foundShardToMove = true;
@@ -580,6 +626,13 @@ public class ShardReplicator
     )
     {
         var (shardId, sourcePeerId, _, targetPeerId, _, replicatorAction, _) = nextReplicationStep;
+
+        var (canCommenceReplication, errorResponse) = await CheckCanCommenceReplication(nextReplicationStep, cancellationToken);
+
+        if (!canCommenceReplication)
+        {
+            return errorResponse;
+        }
 
         switch (replicatorAction)
         {
@@ -760,6 +813,87 @@ public class ShardReplicator
 
             default:
                 throw new InvalidOperationException($"Unknown replicator action {replicatorAction}");
+        }
+    }
+
+    private async Task<(bool CanCommenceReplication, ReplicateShardsToPeerResponse ErrorResponse)> CheckCanCommenceReplication(
+        ScheduledShardReplication nextReplicationStep,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Get current cluster state and compare that the expected cluster state in the replication step
+            // is the same as the obtained current state
+
+            var currentClusterInfo = (
+                    await _qdrantClient.GetClusterInfo(cancellationToken, _clusterName)
+                ).EnsureSuccess();
+
+            var currentCollectionClusteringInfo = (
+                   await _qdrantClient.GetCollectionClusteringInfo(
+                       _collectionName,
+                       cancellationToken,
+                       clusterName: _clusterName
+                   )
+               ).EnsureSuccess();
+
+            var currentCollectionClusteringState = new CollectionClusteringState(
+                currentClusterInfo,
+                currentCollectionClusteringInfo,
+                _targetReplicationFactor
+            );
+
+            var ongoingShardTransfersCount = currentCollectionClusteringInfo.ShardTransfers.Length;
+
+            if (ongoingShardTransfersCount != 0)
+            {
+                // We don't allow performing any replication-related operations while there are any ongoing shard transfers
+
+                // Clear the plan to force user to retry operation from the beginning
+                _shardReplicationsToExecute.Clear();
+
+                return (
+                    false,
+                    new ReplicateShardsToPeerResponse()
+                    {
+                        Result = null,
+                        Status = QdrantStatus.Fail($"Can't restore shard replication factor. Found {ongoingShardTransfersCount} ongoing shard transfers. To ensure that collection data is not corrupted, wait for ongoing shard transfers to finish and start restore shard replication factor process again.")
+                    }
+                );
+            }
+
+            if (!currentCollectionClusteringState.Equals(nextReplicationStep.ExpectedInitialState))
+            {
+                // We don't allow performing any replication-related when cluster is in unexpected state
+
+                // Clear the plan to force user to retry operation from the beginning
+                _shardReplicationsToExecute.Clear();
+
+                return (
+                    false,
+                    new ReplicateShardsToPeerResponse()
+                    {
+                        Result = null,
+                        Status = QdrantStatus.Fail($"Can't restore shard replication factor. Looks like collection clustering was changed parallel to the replication process by ShardReplicator. To ensure that collection data is not corrupted, restart restore shard replication factor process.")
+                    }
+                );
+            }
+
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            // Clear the plan to force user to retry operation from the beginning
+            _shardReplicationsToExecute.Clear();
+
+            return (
+                false,
+                new ReplicateShardsToPeerResponse()
+                {
+                    Result = null,
+                    Status = QdrantStatus.Fail($"Can't restore shard replication factor. An exception happened : {ex}.")
+                }
+            );
         }
     }
 

--- a/src/Aer.QdrantClient.Http/Models/Responses/GetCollectionClusteringInfoResponse.cs
+++ b/src/Aer.QdrantClient.Http/Models/Responses/GetCollectionClusteringInfoResponse.cs
@@ -90,14 +90,20 @@ public sealed class GetCollectionClusteringInfoResponse
         public ReshardingOperationInfo[] ReshardingOperations { init; get; }
 
         /// <summary>
-        /// Gets the mapping of peer identifiers to the list of shard identifiers replicated on them .
+        /// Gets the mapping of peer identifiers to the collection of shard identifiers replicated on them .
         /// </summary>
         public Dictionary<ulong, HashSet<uint>> ShardsByPeers { internal set; get; }
 
         /// <summary>
-        /// Gets the mapping of shard identifiers to the list of peer identifiers they are replicated on.
+        /// Gets the mapping of shard identifiers to the collection of peer identifiers they are replicated on.
         /// </summary>
         public Dictionary<uint, HashSet<ulong>> PeersByShards { internal set; get; }
+
+        /// <summary>
+        /// Gets the mapping of shard identifiers to the mapping from peers identifiers to the states the replicas on those peers.
+        /// First key - shard id, second key - peer id, value - shard state.
+        /// </summary>
+        public Dictionary<uint, Dictionary<ulong, ShardState>> ShardStates { internal set; get; }
     }
 
     /// <summary>

--- a/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.CompoundOperations.cs
+++ b/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.CompoundOperations.cs
@@ -638,34 +638,20 @@ public partial class QdrantHttpClient
                 )
             ).EnsureSuccess();
 
-            if (collectionClusteringInfo.ShardTransfers.Length > 0)
-            {
-                // We don't allow starting any replication-related operations while there are any ongoing shard transfers
-
-                return new RestoreShardReplicationFactorResponse()
-                {
-                    Result = null,
-                    Status = QdrantStatus.Fail($"Can't restore shard replication factor while there are ongoing shard transfers. Found {collectionClusteringInfo.ShardTransfers} ongoing shard transfers, wait for them to finish and start again"),
-                    Time = sw.Elapsed.TotalSeconds
-                };
-            }
-
             var shardReplicator = new ShardReplicator(
                 this,
                 logger,
-                collectionName
+                collectionName,
+                clusterName
             );
 
-            shardReplicator.Calculate(clusterInfo, collectionInfo, collectionClusteringInfo);
+            var ret = shardReplicator.Calculate(clusterInfo, collectionInfo, collectionClusteringInfo);
 
             sw.Stop();
 
-            return new RestoreShardReplicationFactorResponse()
-            {
-                Result = shardReplicator,
-                Status = QdrantStatus.Success(),
-                Time = sw.Elapsed.TotalSeconds
-            };
+            ret.Time = sw.Elapsed.TotalSeconds;
+
+            return ret;
         }
         catch (QdrantUnsuccessfulResponseStatusException qex)
         {

--- a/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.CompoundOperations.cs
+++ b/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.CompoundOperations.cs
@@ -638,6 +638,18 @@ public partial class QdrantHttpClient
                 )
             ).EnsureSuccess();
 
+            if (collectionClusteringInfo.ShardTransfers.Length > 0)
+            {
+                // We don't allow starting any replication-related operations while there are any ongoing shard transfers
+
+                return new RestoreShardReplicationFactorResponse()
+                {
+                    Result = null,
+                    Status = QdrantStatus.Fail($"Can't restore shard replication factor while there are ongoing shard transfers. Found {collectionClusteringInfo.ShardTransfers} ongoing shard transfers, wait for them to finish and start again"),
+                    Time = sw.Elapsed.TotalSeconds
+                };
+            }
+
             var shardReplicator = new ShardReplicator(
                 this,
                 logger,
@@ -654,7 +666,6 @@ public partial class QdrantHttpClient
                 Status = QdrantStatus.Success(),
                 Time = sw.Elapsed.TotalSeconds
             };
-
         }
         catch (QdrantUnsuccessfulResponseStatusException qex)
         {

--- a/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.cs
+++ b/src/Aer.QdrantClient.Http/QdrantHttpClient.Cluster.cs
@@ -121,6 +121,8 @@ public partial class QdrantHttpClient
             // Assume each peer has the same number of shard replicas
             var peersByShards = new Dictionary<uint, HashSet<ulong>>(collectionShardingInfo.Result.LocalShards.Length);
 
+            var shardStates = new Dictionary<uint, Dictionary<ulong, ShardState>>();
+
             var answeringPeerId = collectionShardingInfo.Result.PeerId;
 
             // Collect local shards
@@ -130,6 +132,13 @@ public partial class QdrantHttpClient
             foreach (var shard in collectionShardingInfo.Result.LocalShards)
             {
                 var shardId = shard.ShardId;
+
+                var shardState = shard.State;
+
+                shardStates.Add(shardId, new Dictionary<ulong, ShardState>()
+                {
+                    [answeringPeerId] = shardState
+                });
 
                 shardsByPeers[answeringPeerId].Add(shardId);
 
@@ -149,6 +158,19 @@ public partial class QdrantHttpClient
             {
                 var shardPeer = shard.PeerId;
                 var shardId = shard.ShardId;
+                var shardState = shard.State;
+
+                if (!shardStates.TryGetValue(shardId, out var existingPeerStates))
+                {
+                    shardStates.Add(shardId, new Dictionary<ulong, ShardState>()
+                    {
+                        [shardPeer] = shardState
+                    });
+                }
+                else
+                {
+                    existingPeerStates.Add(shardPeer, shardState);
+                }
 
 #pragma warning disable CA1854 // Justification: we intend to check and then add key-value pair to avoid allocating new list
                 if (!shardsByPeers.ContainsKey(shardPeer))
@@ -171,6 +193,7 @@ public partial class QdrantHttpClient
 
             collectionShardingInfo.Result.ShardsByPeers = shardsByPeers;
             collectionShardingInfo.Result.PeersByShards = peersByShards;
+            collectionShardingInfo.Result.ShardStates = shardStates;
         }
 
         return collectionShardingInfo;

--- a/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Cluster/ClusterCompoundOperationsTestsRestoreReplication.cs
+++ b/tests/Aer.QdrantClient.Tests/TestClasses/HttpClientTests/Cluster/ClusterCompoundOperationsTestsRestoreReplication.cs
@@ -53,6 +53,11 @@ internal class ClusterCompoundOperationsTestsRestoreReplication : QdrantTestsBas
         shardReplicator.ShardsNeedReplication.Should().BeFalse();
 
         shardReplicator.ReplicationPlan.Should().BeEmpty();
+
+        var nonexistentReplicationExecuteResult = await shardReplicator.ExecuteNextReplication(CancellationToken.None);
+
+        nonexistentReplicationExecuteResult.Status.IsSuccess.Should().BeFalse();
+        nonexistentReplicationExecuteResult.Status.GetErrorMessage().Should().Contain("No replications to execute");
     }
 
     [Test]
@@ -90,11 +95,11 @@ internal class ClusterCompoundOperationsTestsRestoreReplication : QdrantTestsBas
 
         var node1Info = (await _qdrantHttpClient1.GetPeerInfo("qdrant-11", CancellationToken.None)).EnsureSuccess();
 
-        var node2Info = (await _qdrantHttpClient1.GetPeerInfo("qdrant-12", CancellationToken.None)).EnsureSuccess();
+        var node2Info = (await _qdrantHttpClient2.GetPeerInfo("qdrant-12", CancellationToken.None)).EnsureSuccess();
 
-        var node3Info = (await _qdrantHttpClient1.GetPeerInfo("qdrant-13", CancellationToken.None)).EnsureSuccess();
+        var node3Info = (await _qdrantHttpClient3.GetPeerInfo("qdrant-13", CancellationToken.None)).EnsureSuccess();
 
-        // Since we are collection shards by peers straight and reversed dictionaries we can use collection info on only one peer
+        // Since obtained collection clustering info contains all shards by peers straight and reversed dictionaries we can use any peer info
 
         var node1ShardState = (
             await _qdrantHttpClient1.GetCollectionClusteringInfo(
@@ -235,7 +240,7 @@ internal class ClusterCompoundOperationsTestsRestoreReplication : QdrantTestsBas
 
             singleShardReplicationResult.IsSuccess.Should().BeTrue();
 
-            // Wait for replication to complete before moving to the next shard
+            // Wait for replication to complete before moving to the next replication step
             await _qdrantHttpClient1.EnsureCollectionReady(
                 TestCollectionName,
                 CancellationToken.None,
@@ -258,5 +263,143 @@ internal class ClusterCompoundOperationsTestsRestoreReplication : QdrantTestsBas
             )
             .Should()
             .BeTrue();
+    }
+
+    [Test]
+    public async Task RestoreShardReplicationFactor_ParallelCollectionUpdate()
+    {
+        // The test itself is basically the same as RestoreShardReplicationFactor but on the second replication step
+        // we change collection clustering to be different from expected one
+
+        await PrepareCollection(
+            _qdrantHttpClient1,
+            TestCollectionName,
+            replicationFactor: 2,
+            vectorCount: 100,
+            shardCount: 6
+        );
+
+        var node1Info = (await _qdrantHttpClient1.GetPeerInfo("qdrant-11", CancellationToken.None)).EnsureSuccess();
+
+        var node2Info = (await _qdrantHttpClient2.GetPeerInfo("qdrant-12", CancellationToken.None)).EnsureSuccess();
+
+        // Since obtained collection clustering info contains all shards by peers straight and reversed dictionaries we can use any peer info
+
+        var node1ShardState = (
+            await _qdrantHttpClient1.GetCollectionClusteringInfo(
+                TestCollectionName,
+                CancellationToken.None,
+                isTranslatePeerIdsToUris: true
+            )
+        ).EnsureSuccess();
+
+        // Prepare initial unbalanced cluster state. Two imbalances is enough since we are going to change collection clustering after the first replication
+
+        var notFoundShardId = 1567U; // sentinel value for indicating that shard was not found
+
+        // Copy one shard from node 2 to node 1
+
+        var shardNotPresentOnNode1 = node1ShardState
+            .ShardsByPeers[node2Info.PeerId]
+            .Except(node1ShardState.ShardsByPeers[node1Info.PeerId])
+            .FirstOrDefault(notFoundShardId);
+
+        shardNotPresentOnNode1.Should().NotBe(notFoundShardId);
+
+        (
+            await _qdrantHttpClient1.ReplicateShards(
+                sourcePeerId: node2Info.PeerId,
+                targetPeerId: node1ShardState.PeerId,
+                CancellationToken.None,
+                collectionNamesToReplicate: [TestCollectionName],
+                shardIdsToReplicate: [shardNotPresentOnNode1]
+            )
+        ).EnsureSuccess();
+
+        // Delete one shard from node 2 (not the one we copied)
+
+        var shardToDeleteFromNode2 = node1ShardState.ShardsByPeers[node2Info.PeerId].Except([shardNotPresentOnNode1]).First();
+
+        (
+            await _qdrantHttpClient1.DropCollectionShardsFromPeer(
+                TestCollectionName,
+                peerId: node2Info.PeerId,
+                shardIds: [shardToDeleteFromNode2],
+                CancellationToken.None
+            )
+        ).EnsureSuccess();
+
+        await _qdrantHttpClient1.EnsureCollectionReady(
+            TestCollectionName,
+            CancellationToken.None,
+            isCheckShardTransfersCompleted: true
+        );
+
+        await _qdrantHttpClient2.EnsureCollectionReady(
+            TestCollectionName,
+            CancellationToken.None,
+            isCheckShardTransfersCompleted: true
+        );
+
+        await _qdrantHttpClient3.EnsureCollectionReady(
+            TestCollectionName,
+            CancellationToken.None,
+            isCheckShardTransfersCompleted: true
+        );
+
+        // Restore replication factor
+
+        var restoreReplicationFactorResponse = await _qdrantHttpClient1.RestoreShardReplicationFactor(
+            TestCollectionName,
+            CancellationToken.None
+        );
+
+        restoreReplicationFactorResponse.Status.IsSuccess.Should().BeTrue();
+
+        var shardReplicator = restoreReplicationFactorResponse.Result;
+
+        shardReplicator.ShardsNeedReplication.Should().BeTrue();
+
+        shardReplicator.ReplicationPlan.Should().NotBeEmpty();
+
+        shardReplicator.ReplicationPlan.Count.Should().Be(2);
+
+        var firstReplicationResult = await shardReplicator.ExecuteNextReplication(CancellationToken.None);
+
+        firstReplicationResult.Status.IsSuccess.Should().BeTrue();
+
+        // Wait for replication to complete before moving to the next replication step
+        await _qdrantHttpClient1.EnsureCollectionReady(
+            TestCollectionName,
+            CancellationToken.None,
+            isCheckShardTransfersCompleted: true
+        );
+
+        // Change collection clustering inf so that the expected state is different from an actual one
+        // Any change will do, so we just redo the initial unbalancing that should have been fixed by first replication.
+
+        (
+            await _qdrantHttpClient1.ReplicateShards(
+                sourcePeerId: node2Info.PeerId,
+                targetPeerId: node1ShardState.PeerId,
+                CancellationToken.None,
+                collectionNamesToReplicate: [TestCollectionName],
+                shardIdsToReplicate: [shardNotPresentOnNode1]
+            )
+        ).EnsureSuccess();
+
+        await _qdrantHttpClient1.EnsureCollectionReady(
+            TestCollectionName,
+            CancellationToken.None,
+            isCheckShardTransfersCompleted: true
+        );
+
+        // Try to commence next replication step - it should fail
+        var secondReplicationAfterClusterChangeResult = await shardReplicator.ExecuteNextReplication(CancellationToken.None);
+
+        secondReplicationAfterClusterChangeResult.Status.IsSuccess.Should().BeFalse();
+        secondReplicationAfterClusterChangeResult.Status.GetErrorMessage().Should()
+            .Contain("Can't restore shard replication factor")
+            .And.Contain("collection clustering was changed");
     }
 }


### PR DESCRIPTION
Greatly improved `ShardReplicator` logic;

Add checking that shard transfers are over before proceeding with shard replicator; 
Add removal of inactive nodes to shard replicator; 
Add `ShardReplicator.ExecuteNextReplication` method as an alternative to `await foreach` approach to execute replications;
Add checking that cluster sate was not externally changed prior to commencing with the next replication step;
